### PR TITLE
Paoloprogram12/ReusableBoardHeader

### DIFF
--- a/src/app/board/page.tsx
+++ b/src/app/board/page.tsx
@@ -3,7 +3,7 @@ import Header from "@/components/board/Header";
 const Board = () => {
   return (
     <div className="flex h-screen w-screen items-center justify-center">
-      <Header title = "Executives"/>
+      <Header title="Executives" />
     </div>
   );
 };

--- a/src/components/board/Header.tsx
+++ b/src/components/board/Header.tsx
@@ -1,17 +1,17 @@
 interface HeaderTitles {
-    title: string;
+  title: string;
 }
 
 const Header = ({ title }: HeaderTitles) => {
-    return (
-        <div className="flex w-full flex-col gap-8">
-            <div className="bg-gradient-to-r from-white via-agsm-blue-100 to-white p-4">
-                <p className="text-agsm-blue-200 font-agsm-main text-center text-4xl font-bold">
-                    {title}
-                </p>
-            </div>
-        </div>
-    );
+  return (
+    <div className="flex w-full flex-col gap-8">
+      <div className="via-agsm-blue-100 bg-gradient-to-r from-white to-white p-4">
+        <p className="text-agsm-blue-200 font-agsm-main text-center text-4xl font-bold">
+          {title}
+        </p>
+      </div>
+    </div>
+  );
 };
 
 export default Header;


### PR DESCRIPTION

<img width="1439" height="653" alt="Screenshot 2026-02-10 at 5 03 34 PM" src="https://github.com/user-attachments/assets/e3f5561f-bf7b-4315-88f9-40d175798966" />
Included the Executive Board Header. Also Included the use of the interface property so it can become reusable.